### PR TITLE
ebs-deploy: Deploy version check fix and throttling fix for describe_events()

### DIFF
--- a/ebs_deploy/__init__.py
+++ b/ebs_deploy/__init__.py
@@ -77,6 +77,12 @@ def parse_env_config(config, env_name):
 def upload_application_archive(helper, env_config, archive=None, directory=None, version_label=None):
     if version_label is None:
         version_label = datetime.now().strftime('%Y%m%d_%H%M%S')
+    else:
+        # don't attempt to create an application version which already exists
+        existing_version_labels = [version['VersionLabel'] for version in helper.get_versions()]
+        if version_label in existing_version_labels:
+            return version_label
+
     archive_file_name = None
     if archive:
         archive_file_name = os.path.basename(archive)

--- a/ebs_deploy/__init__.py
+++ b/ebs_deploy/__init__.py
@@ -553,7 +553,15 @@ class EbsHelper(object):
                     out(msg + " ... waiting")
 
                 # log events
-                (events, next_token) = self.describe_events(env_name, start_time=datetime.now().isoformat())
+                try:
+                    (events, next_token) = self.describe_events(env_name, start_time=datetime.now().isoformat())
+                except BotoServerError as e:
+                    if not e.error_code == 'Throttling':
+                        raise
+                    delay = min(60, int(delay * 1.5))
+                    out("Throttling: setting delay to " + str(delay) + " seconds")
+                    break
+
                 for event in events:
                     if event not in seen_events:
                         out("["+event['Severity']+"] "+event['Message'])

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
 
     # general meta
     name='ebs-deploy',
-    version='1.9.12',
+    version='1.9.13',
     author='Brian C. Dilley',
     author_email='brian.dilley@gmail.com',
     description='Python based command line tools for managing '


### PR DESCRIPTION
## Summary

Several recent Hub builds have failed because STG and PROD had the same app version. This fixes that by incorporating an app version check that @morganiq wrote about a year ago.

A recent Lectern build failed because the Boto call  `describe_events()` produced a throttling error: `BotoServerError: 400 Bad Request {"Error":{"Code":"Throttling","Message":"Rate exceeded","Type":"Sender"},"RequestId":"703b1578-3f3b-11e7-b091-7be356a285cd"}`
This fixes that by checking for the error and continuing with the parent loop.

Bumped `eps-deploy` to 1.9.13, and uploaded to pypi. If there are changes to this PR, a version change might be needed, and a re-upload pypi will definitely be needed.

## Code Details

Copied this app version check: https://github.com/cookbrite/ebs-deploy/commit/834f174d243df2c1fa7fa2365732874d7551c4b4

Applied this throttling retry originally for `describe_environments()`: https://github.com/cookbrite/ebs-deploy/commit/dc67f7dfd17e45eedd6f105aeecf6b7fd3fcfaa3

## TODO

- Other calls to `describe_environments()` have produced the throttling error; we should consider whether / how to handle the issue there.
- We should consider changing our `ebs-deploy` fork to a new name, to avoid possible version conflicts, if `ebs-deploy` ever starts getting updates.

## Testing

- Tried to locally deploy new Hub app version to STG with old `ebs-deploy`, watched it fail, and then watched it succeed when using this `ebs-deploy`.
- Unable to test the handling of throttling errors when calling `describe_events()`, as that is not reproducible on demand.
