### PR TITLE
bugfix for EB env name race

### DIFF
--- a/ebs_deploy/__init__.py
+++ b/ebs_deploy/__init__.py
@@ -319,12 +319,12 @@ class EbsHelper(object):
                                     tier_name=tier_name,
                                     tier_version=tier_version)
 
-    def environment_exists(self, env_name):
+    def environment_exists(self, env_name, include_deleted=False):
         """
         Returns whether or not the given environment exists
         """
         response = self.ebs.describe_environments(application_name=self.app_name, environment_names=[env_name],
-                                                  include_deleted=False)
+                                                  include_deleted=include_deleted)
         return len(response['DescribeEnvironmentsResponse']['DescribeEnvironmentsResult']['Environments']) > 0 \
                and response['DescribeEnvironmentsResponse']['DescribeEnvironmentsResult']['Environments'][0][
                        'Status'] != 'Terminated'

--- a/ebs_deploy/commands/zdt_deploy_command.py
+++ b/ebs_deploy/commands/zdt_deploy_command.py
@@ -44,12 +44,12 @@ def execute(helper, config, args):
     # find an available environment name
     out("Determining new environment name...")
     new_env_name = None
-    if not helper.environment_exists(args.environment):
+    if not helper.environment_exists(args.environment, include_deleted=True):
         new_env_name = args.environment
     else:
         for i in xrange(10):
             temp_env_name = args.environment + '-' + str(i)
-            if not helper.environment_exists(temp_env_name):
+            if not helper.environment_exists(temp_env_name, include_deleted=True):
                 new_env_name = temp_env_name
                 break
     if new_env_name is None:


### PR DESCRIPTION
So here's what I determined is happening with some (all?!) of our deploys:

1. Jenkins deploy for an app deletes old EB environment for app
2. old EB env for app goes into pending deletion state (light gray)
3. Jenkins deploy for app uses ebs-deploy [some code](https://github.com/briandilley/ebs-deploy/blob/master/ebs_deploy/commands/zdt_deploy_command.py#L42-L57) to determine the name of the new EB app environment.  This name is **only** for polling purposes, because EB will determine the name itself.  The assumption is that the name we determine matches the name EB determines for the new env.
4. The new name is actually the name of the currently-deleting environment(!) due to a race in how we're checking to see if the name is already in use.
5. EB starts spinning up new env for app, with a name that we are not expecting.
6. Jenkins EB deploy waiting indefinitely for (what it thinks is) the new app environment to turn green, but actually it's the old env being gray and deleting
7. EB successfully deploys new app env, turning it green
8. We're still polling the wrong env name, until we time out and the build "fails"

This is supported by the following log entries:
https://cookbrite.ci.cloudbees.com/job/Build-Jobs/job/lectern-dev-stage/1139/console
```
13:09:31 Determining new environment name...
13:09:31 New environment name will be cookbrite-stg-abbey
13:09:31 Determining new environment cname...
13:09:31 New environment cname will be cookbrite-stg-abbey-0-0
```
The new name that was determined was the name of the gray (old, deleting) env at the time the build failed.  A new app env eventually came up green, and it had the name of `cookbrite-dev-abbey-0`, which was not what we were polling for.

I believe the only reason deploys worked *sometimes* was that the initial delete step (step 1) took awhile to transition the env to a gray/deleting state, meaning the name-checker code was seeing that the name was in use, and picking the logical (correct) next name.  But when the env quickly transitioned to a deleting state, the name-checker code said "oh looks like that name isn't in use anymore, let's assume EB's next env will have that name."  The fix here is to tell our deploy scripts to also verify that the name we're going to poll also doesn't belong to an env that is being spun down.