### PR TITLE
Bugfix/exact match previous env

### DIFF
--- a/ebs_deploy/__init__.py
+++ b/ebs_deploy/__init__.py
@@ -468,7 +468,7 @@ class EbsHelper(object):
 
         def match_cname(cname):
             subdomain = sanitize_subdomain(cname.split(".")[0])
-            return subdomain.startswith(env_subdomain)
+            return subdomain == env_subdomain
 
         def match_candidate(env):
             return env['Status'] != 'Terminated' \
@@ -477,7 +477,6 @@ class EbsHelper(object):
 
         envs = self.get_environments()
         candidates = [env for env in envs if match_candidate(env)]
-        candidates.sort(key=lambda env: env["DateUpdated"], reverse=True)
 
         match = None
         if candidates:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
 
     # general meta
     name='ebs-deploy',
-    version='1.9.19',
+    version='1.9.20',
     author='Brian C. Dilley,MetaBrite',
     author_email='brian.dilley@gmail.com',
     description='Python based command line tools for managing '


### PR DESCRIPTION
We never want a `startswith` match, only an exact match, which should only return 0 or 1 envs.  Imagine a scenario where we are deploying hub to dev and there's two existing green clusters (for some reason).

env1_subdomain = "cookbrite-dev-hub2-0-a3bfg78"
env2_subdomain = "cookbrite-dev-hub2-0"

if env1 was altered after env2, we would attempt to swap cnames from that, because the subdomain we are looking for starts with "cookbrite-dev-hub2-0".  This is not what we want.  We should always do an exact match on the env subdomain, because the active env (the one route 53 points to) never changes (due to swapping), and we always know it in advance.