### PR TITLE
start time now in utc with Zulu timezone designator

### DIFF
--- a/ebs_deploy/__init__.py
+++ b/ebs_deploy/__init__.py
@@ -20,6 +20,10 @@ LOGGER_NAME = 'ebs_deploy'
 MAX_RED_SAMPLES = 20
 
 
+def utcnow_isoformat():
+    return datetime.utcnow().isoformat() + 'Z'
+
+
 def out(message):
     """
     print alias
@@ -544,6 +548,7 @@ class EbsHelper(object):
         """
         Describes events from the given environment
         """
+
         events = self.ebs.describe_events(
             application_name=self.app_name,
             environment_name=environment_name,
@@ -580,7 +585,7 @@ class EbsHelper(object):
         seen_events = list()
 
         for env_name in environment_names:
-            (events, next_token) = self.describe_events(env_name, start_time=datetime.now().isoformat())
+            (events, next_token) = self.describe_events(env_name, start_time=utcnow_isoformat())
             for event in events:
                 seen_events.append(event)
 
@@ -650,7 +655,7 @@ class EbsHelper(object):
 
                 # log events
                 try:
-                    (events, next_token) = self.describe_events(env_name, start_time=datetime.now().isoformat())
+                    (events, next_token) = self.describe_events(env_name, start_time=utcnow_isoformat())
                 except BotoServerError as e:
                     if not e.error_code == 'Throttling':
                         raise

--- a/ebs_deploy/commands/deploy_command.py
+++ b/ebs_deploy/commands/deploy_command.py
@@ -1,4 +1,4 @@
-from ebs_deploy import get, parse_env_config, parse_option_settings, upload_application_archive
+from ebs_deploy import utcnow_isoformat, get, parse_env_config, parse_option_settings, upload_application_archive
 
 
 def add_arguments(parser):
@@ -28,7 +28,7 @@ def execute(helper, config, args):
         directory=args.directory, version_label=version_label)
 
     import datetime
-    start_time = datetime.datetime.utcnow().isoformat()
+    start_time = utcnow_isoformat()
     # deploy it
     helper.deploy_version(env_name, version_label)
 

--- a/ebs_deploy/commands/describe_events_command.py
+++ b/ebs_deploy/commands/describe_events_command.py
@@ -1,6 +1,5 @@
-import time
-from ebs_deploy import out, get, parse_env_config, parse_option_settings, upload_application_archive
-from datetime import datetime
+from ebs_deploy import utcnow_isoformat
+
 
 def add_arguments(parser):
     """
@@ -15,7 +14,7 @@ def execute(helper, config, args):
     """
     environment_name = args.environment
 
-    (events, next_token) = helper.describe_events(environment_name, start_time=datetime.now().isoformat())
+    (events, next_token) = helper.describe_events(environment_name, start_time=utcnow_isoformat())
 
     # swap C-Names
     for event in events:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
 
     # general meta
     name='ebs-deploy',
-    version='1.9.22',
+    version='1.9.23',
     author='Brian C. Dilley, MetaBrite',
     author_email='brian.dilley@gmail.com',
     description='Python based command line tools for managing '


### PR DESCRIPTION
## Summary
Change timestamps to UTC time with Z for Zulu time designator because AWS started strictly enforcing ISO8601 timestamps yesterday 

## Impact
* Deployments to Elastic Beanstalk do not fail

## Detail
Python doesn't put a timezone designator at the end of a timestamp by default. On 2018-01-17, Beanstalk started strictly enforcing ISO8601 date formatting, causing our builds to fail.
* Change `datetime.now` to `datetime.utcnow` and add `Z` suffix
* Bump version

## Limitations/TODO
- [ ]  manually deploy to pypi

## Testing
Manual testing.