### PR TITLE
bump version and prefix package name with mb

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@ from setuptools import setup
 setup(
 
     # general meta
-    name='ebs-deploy',
-    version='1.9.23',
+    name='mb-ebs-deploy',
+    version='1.9.24',
     author='Brian C. Dilley, MetaBrite',
     author_email='brian.dilley@gmail.com',
     description='Python based command line tools for managing '


### PR DESCRIPTION
Brian Dilley has started updating `ebs-deploy` here: https://github.com/briandilley/ebs-deploy/

In order to keep our current functionality, rename our forked package to `mb-ebs-deploy`.

Pair: @georgevreilly and @j-heller